### PR TITLE
Refactor sdk/compiler/handlers to split into smaller files

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -43,16 +43,6 @@ Metrics/MethodLength:
 Metrics/PerceivedComplexity:
   Max: 11
 
-# Offense count: 4
-# Configuration parameters: MinNameLength, AllowNamesEndingInNumbers, AllowedNames, ForbiddenNames.
-# AllowedNames: io, id, to
-Naming/UncommunicativeMethodParamName:
-  Exclude:
-    - 'lib/neo/sdk/compiler/processor.rb'
-    - 'lib/neo/utils.rb'
-    - 'lib/neo/vm/context.rb'
-    - 'lib/neo/vm/stack.rb'
-
 # Offense count: 15
 Style/Documentation:
   Exclude:
@@ -73,9 +63,3 @@ Style/Documentation:
     - 'lib/neo/script.rb'
     - 'lib/neo/transaction/miner.rb'
     - 'lib/neo/utils/var_int.rb'
-
-# Offense count: 1
-# Configuration parameters: MinBodyLength.
-Style/GuardClause:
-  Exclude:
-    - 'lib/neo/sdk/compiler/handlers.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -39,10 +39,6 @@ Metrics/CyclomaticComplexity:
 Metrics/MethodLength:
   Max: 39
 
-# Offense count: 1
-Metrics/PerceivedComplexity:
-  Max: 11
-
 # Offense count: 15
 Style/Documentation:
   Exclude:

--- a/lib/neo/sdk/compiler/handlers.rb
+++ b/lib/neo/sdk/compiler/handlers.rb
@@ -138,15 +138,15 @@ module Neo
         def on_const(node)
           super
           _mod, klass = *node
-          position = find_local klass
 
-          if position
-            emit :FROMALTSTACK
-            emit :DUP
-            emit :TOALTSTACK
-            emit_push position
-            emit :PICKITEM
-          end
+          position = find_local klass
+          return unless position
+
+          emit :FROMALTSTACK
+          emit :DUP
+          emit :TOALTSTACK
+          emit_push position
+          emit :PICKITEM
         end
 
         # TODO: Refactor to remove duplication with on_args

--- a/lib/neo/sdk/compiler/handlers.rb
+++ b/lib/neo/sdk/compiler/handlers.rb
@@ -1,11 +1,20 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ModuleLength
 module Neo
   module SDK
     class Compiler
       # Handle ruby features, emit Neo bytecode
       module Handlers
+        require 'neo/sdk/compiler/handlers/assignments'
+        require 'neo/sdk/compiler/handlers/control_expressions'
+        require 'neo/sdk/compiler/handlers/literals'
+        require 'neo/sdk/compiler/handlers/methods'
+
+        include Assignments
+        include ControlExpressions
+        include Literals
+        include Methods
+
         OPERATORS = {
           :+      => :ADD,
           :-      => :SUB,
@@ -45,228 +54,7 @@ module Neo
           Transaction
           Validator
         ].freeze
-
-        def on_begin(node)
-          node.children.each { |c| process(c) }
-        end
-
-        # rubocop:disable Metrics/AbcSize
-        def on_def(node)
-          name, args_node, body_node = *node
-          if name == :main
-            process body_node
-            emit :FROMALTSTACK
-            emit :DROP
-            emit :RET
-          else
-            method_body = Processor.new nil, self, logger
-            method_body.emit :NOP
-            method_body.emit :NEWARRAY
-            method_body.emit :TOALTSTACK
-            method_body.process args_node
-            method_body.process body_node
-            method_body.emit :FROMALTSTACK
-            method_body.emit :DROP
-            method_body.emit :RET
-            raise NotImplementedError if method_body.depth > 16
-            method_body.first.update name: "PUSH#{method_body.depth}".to_sym
-            definitions[name] = method_body
-          end
-          logger.info "Method `#{name}` defined."
-        end
-        # rubocop:enable Metrics/AbcSize
-
-        def on_return(node)
-          super
-          emit :RET
-        end
-
-        def on_if(node)
-          condition_node, then_node, else_node = *node
-          process condition_node
-
-          jump_a = emit :JMPIFNOT, :nil
-          Processor.new then_node, self, logger
-          if else_node
-            jump_b = emit :JMP, :nil
-            else_clause = Processor.new else_node, self, logger
-            else_end = emit :NOP
-            jump_a.update data: else_clause.first
-            jump_b.update data: else_end
-          else
-            then_end = emit :NOP
-            jump_a.update data: then_end
-          end
-        end
-
-        def on_while(node)
-          condition_node, body_node = *node
-          jump = emit :JMP, :nil
-          body = Processor.new body_node, self, logger
-          condition = Processor.new condition_node, self, logger
-          emit :JMPIF, body.first
-          jump.update data: condition.first
-        end
-
-        # TODO: I think this is where I need to handle optional/default args
-        def on_args(node)
-          node.children.each.with_index do |arg, position|
-            name, = *arg
-            @locals << name
-            emit :FROMALTSTACK
-            emit :DUP
-            emit :TOALTSTACK
-            emit_push position
-            emit_push 2
-            emit :ROLL
-            emit :SETITEM
-          end
-        end
-
-        def on_lvar(node)
-          super
-          name, = *node
-          position = find_local name
-
-          emit :FROMALTSTACK
-          emit :DUP
-          emit :TOALTSTACK
-          emit_push position
-          emit :PICKITEM
-        end
-
-        def on_const(node)
-          super
-          _mod, klass = *node
-
-          position = find_local klass
-          return unless position
-
-          emit :FROMALTSTACK
-          emit :DUP
-          emit :TOALTSTACK
-          emit_push position
-          emit :PICKITEM
-        end
-
-        # TODO: Refactor to remove duplication with on_args
-        def on_lvasgn(node)
-          super
-          name, = *node
-          position = find_local name
-          # TODO: should be able to shadow variable scope
-          unless position
-            position = locals.length
-            @locals << name
-          end
-
-          emit :FROMALTSTACK
-          emit :DUP
-          emit :TOALTSTACK
-          emit_push position
-          emit_push 2
-          emit :ROLL
-          emit :SETITEM
-        end
-
-        # TODO: Refactor to remove duplication with on_lvasgn
-        def on_casgn(node)
-          super
-          _scope, name, = *node
-          position = find_local name
-          if position
-            # TODO: raise error, can't re-assign contstant
-          else
-            position = locals.length
-            @locals << name
-          end
-
-          emit :FROMALTSTACK
-          emit :DUP
-          emit :TOALTSTACK
-          emit_push position
-          emit_push 2
-          emit :ROLL
-          emit :SETITEM
-        end
-
-        def on_op_asgn(node)
-          receiver, name, *args = *node
-          position = find_local receiver.children.first
-          emit :FROMALTSTACK
-          emit :DUP
-          emit :TOALTSTACK
-          emit_push position
-          emit :PICKITEM
-          process_all args
-          emit OPERATORS[name] if OPERATORS.key? name
-          process receiver
-          emit :FROMALTSTACK
-          emit :DUP
-          emit :TOALTSTACK
-          emit_push position
-          emit :PICKITEM
-        end
-
-        # rubocop:disable Metrics/AbcSize
-        def on_send(node)
-          super
-          receiver, name, *_args = *node
-
-          case name
-          when :==
-            emit receiver.type == :int ? :NUMEQUAL : :EQUAL
-          when :!=
-            if receiver.type == :int
-              emit :NUMNOTEQUAL
-            else
-              emit :EQUAL
-              emit :NOT
-            end
-          else
-            if receiver && receiver.type == :const
-              mod, klass = *receiver
-              if !mod && NAMESPACES.include?(klass)
-                prefix = klass == :ExecutionEngine ? 'System' : 'Neo'
-                method = name.to_s.capitalize.gsub(/_([a-z])/) { Regexp.last_match(1).capitalize }
-                emit :SYSCALL, [prefix, klass, method].join('.')
-              end
-            else
-              emit_method name
-            end
-          end
-        end
-        # rubocop:enable Metrics/AbcSize
-
-        def on_str(node)
-          value, = *node
-          emit_push value
-        end
-
-        def on_int(node)
-          value, = *node
-          emit_push value
-        end
-
-        def on_false(*)
-          emit_push false
-        end
-
-        def on_true(*)
-          emit_push true
-        end
-
-        def on_or(*)
-          super
-          emit :BOOLOR
-        end
-
-        def on_and(*)
-          super
-          emit :BOOLAND
-        end
       end
     end
   end
 end
-# rubocop:enable Metrics/ModuleLength

--- a/lib/neo/sdk/compiler/handlers/assignments.rb
+++ b/lib/neo/sdk/compiler/handlers/assignments.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+module Neo
+  module SDK
+    class Compiler
+      module Handlers
+        # Handlers for ruby features
+        # See https://ruby-doc.org/core-2.3.0/doc/syntax_rdoc.html
+        module Assignments
+          # TODO: I think this is where I need to handle optional/default args
+          def on_args(node)
+            node.children.each.with_index do |arg, position|
+              name, = *arg
+              @locals << name
+              emit :FROMALTSTACK
+              emit :DUP
+              emit :TOALTSTACK
+              emit_push position
+              emit_push 2
+              emit :ROLL
+              emit :SETITEM
+            end
+          end
+
+          def on_lvar(node)
+            super
+            name, = *node
+            position = find_local name
+
+            emit :FROMALTSTACK
+            emit :DUP
+            emit :TOALTSTACK
+            emit_push position
+            emit :PICKITEM
+          end
+
+          def on_const(node)
+            super
+            _mod, klass = *node
+
+            position = find_local klass
+            return unless position
+
+            emit :FROMALTSTACK
+            emit :DUP
+            emit :TOALTSTACK
+            emit_push position
+            emit :PICKITEM
+          end
+
+          # TODO: Refactor to remove duplication with on_args
+          def on_lvasgn(node)
+            super
+            name, = *node
+            position = find_local name
+            # TODO: should be able to shadow variable scope
+            unless position
+              position = locals.length
+              @locals << name
+            end
+
+            emit :FROMALTSTACK
+            emit :DUP
+            emit :TOALTSTACK
+            emit_push position
+            emit_push 2
+            emit :ROLL
+            emit :SETITEM
+          end
+
+          # TODO: Refactor to remove duplication with on_lvasgn
+          def on_casgn(node)
+            super
+            _scope, name, = *node
+            position = find_local name
+            if position
+              # TODO: raise error, can't re-assign contstant
+            else
+              position = locals.length
+              @locals << name
+            end
+
+            emit :FROMALTSTACK
+            emit :DUP
+            emit :TOALTSTACK
+            emit_push position
+            emit_push 2
+            emit :ROLL
+            emit :SETITEM
+          end
+
+          def on_op_asgn(node)
+            receiver, name, *args = *node
+            position = find_local receiver.children.first
+            emit :FROMALTSTACK
+            emit :DUP
+            emit :TOALTSTACK
+            emit_push position
+            emit :PICKITEM
+            process_all args
+            emit OPERATORS[name] if OPERATORS.key? name
+            process receiver
+            emit :FROMALTSTACK
+            emit :DUP
+            emit :TOALTSTACK
+            emit_push position
+            emit :PICKITEM
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/neo/sdk/compiler/handlers/control_expressions.rb
+++ b/lib/neo/sdk/compiler/handlers/control_expressions.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Neo
+  module SDK
+    class Compiler
+      module Handlers
+        # Handlers for ruby features
+        # See https://ruby-doc.org/core-2.3.0/doc/syntax_rdoc.html
+        module ControlExpressions
+          def on_begin(node)
+            node.children.each { |c| process(c) }
+          end
+
+          def on_return(node)
+            super
+            emit :RET
+          end
+
+          def on_if(node)
+            condition_node, then_node, else_node = *node
+            process condition_node
+
+            jump_a = emit :JMPIFNOT, :nil
+            Processor.new then_node, self, logger
+            if else_node
+              jump_b = emit :JMP, :nil
+              else_clause = Processor.new else_node, self, logger
+              else_end = emit :NOP
+              jump_a.update data: else_clause.first
+              jump_b.update data: else_end
+            else
+              then_end = emit :NOP
+              jump_a.update data: then_end
+            end
+          end
+
+          def on_while(node)
+            condition_node, body_node = *node
+            jump = emit :JMP, :nil
+            body = Processor.new body_node, self, logger
+            condition = Processor.new condition_node, self, logger
+            emit :JMPIF, body.first
+            jump.update data: condition.first
+          end
+
+          def on_or(*)
+            super
+            emit :BOOLOR
+          end
+
+          def on_and(*)
+            super
+            emit :BOOLAND
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/neo/sdk/compiler/handlers/literals.rb
+++ b/lib/neo/sdk/compiler/handlers/literals.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Neo
+  module SDK
+    class Compiler
+      module Handlers
+        # Handlers for ruby features
+        # See https://ruby-doc.org/core-2.3.0/doc/syntax_rdoc.html
+        module Literals
+          def on_str(node)
+            value, = *node
+            emit_push value
+          end
+
+          def on_int(node)
+            value, = *node
+            emit_push value
+          end
+
+          def on_false(*)
+            emit_push false
+          end
+
+          def on_true(*)
+            emit_push true
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/neo/sdk/compiler/handlers/methods.rb
+++ b/lib/neo/sdk/compiler/handlers/methods.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Neo
+  module SDK
+    class Compiler
+      module Handlers
+        # Handlers for ruby features
+        # See https://ruby-doc.org/core-2.3.0/doc/syntax_rdoc.html
+        module Methods
+          def on_def(node)
+            name, args_node, body_node = *node
+            if name == :main
+              process body_node
+              emit :FROMALTSTACK
+              emit :DROP
+              emit :RET
+            else
+              on_def_method(name, args_node, body_node)
+            end
+            logger.info "Method `#{name}` defined."
+          end
+
+          def on_send(node)
+            super
+            receiver, name, *_args = *node
+
+            case name
+            when :==
+              emit receiver.type == :int ? :NUMEQUAL : :EQUAL
+            when :!=
+              on_send_not_equal(receiver)
+            else
+              on_send_other(receiver, name)
+            end
+          end
+
+          private
+
+          def on_def_method(name, args_node, body_node)
+            method_body = Processor.new nil, self, logger
+            method_body.emit :NOP
+            method_body.emit :NEWARRAY
+            method_body.emit :TOALTSTACK
+            method_body.process args_node
+            method_body.process body_node
+            method_body.emit :FROMALTSTACK
+            method_body.emit :DROP
+            method_body.emit :RET
+            raise NotImplementedError if method_body.depth > 16
+            method_body.first.update name: "PUSH#{method_body.depth}".to_sym
+            definitions[name] = method_body
+          end
+
+          def on_send_not_equal(receiver)
+            if receiver.type == :int
+              emit :NUMNOTEQUAL
+            else
+              emit :EQUAL
+              emit :NOT
+            end
+          end
+
+          def on_send_other(receiver, name)
+            if receiver && receiver.type == :const
+              mod, klass = *receiver
+              if !mod && NAMESPACES.include?(klass)
+                prefix = klass == :ExecutionEngine ? 'System' : 'Neo'
+                method = name.to_s.capitalize.gsub(/_([a-z])/) { Regexp.last_match(1).capitalize }
+                emit :SYSCALL, [prefix, klass, method].join('.')
+              end
+            else
+              emit_method name
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/neo/sdk/compiler/processor.rb
+++ b/lib/neo/sdk/compiler/processor.rb
@@ -62,10 +62,10 @@ module Neo
           record builder.emit_push(data)
         end
 
-        def record(op)
-          op.scope = self
-          @first ||= op
-          @last = op
+        def record(operation)
+          operation.scope = self
+          @first ||= operation
+          @last = operation
         end
 
         def emit_method(name)

--- a/lib/neo/utils.rb
+++ b/lib/neo/utils.rb
@@ -30,12 +30,12 @@ module Neo
 
       BASE = ALPHABET.length
 
-      def self.encode(n)
-        return ALPHABET[0] if n.zero?
+      def self.encode(num)
+        return ALPHABET[0] if num.zero?
         buffer = ''
-        while n.positive?
-          remainder = n % BASE
-          n /= BASE
+        while num.positive?
+          remainder = num % BASE
+          num /= BASE
           buffer = ALPHABET[remainder] + buffer
         end
         buffer

--- a/lib/neo/vm/context.rb
+++ b/lib/neo/vm/context.rb
@@ -23,9 +23,9 @@ module Neo
         byte
       end
 
-      def read_bytes(n)
+      def read_bytes(num)
         bytes = []
-        n.times { bytes << read_byte }
+        num.times { bytes << read_byte }
         ByteArray.new(bytes)
       end
 

--- a/lib/neo/vm/stack.rb
+++ b/lib/neo/vm/stack.rb
@@ -16,8 +16,8 @@ module Neo
         @items.insert index, item
       end
 
-      def peek(n = 0)
-        @items[n]
+      def peek(idx = 0)
+        @items[idx]
       end
 
       def pop


### PR DESCRIPTION
Fix some issues on rubocop and refactored the way code is organized around sdk/compilers/handlers